### PR TITLE
Added a init function

### DIFF
--- a/simple-serial-port/simple-serial-port/SimpleSerial.cpp
+++ b/simple-serial-port/simple-serial-port/SimpleSerial.cpp
@@ -1,7 +1,7 @@
 #include "stdafx.h"
 #include "SimpleSerial.h"
 
-SimpleSerial::SimpleSerial(char* com_port, DWORD COM_BAUD_RATE)
+void SimpleSerial::init(char* com_port, DWORD COM_BAUD_RATE)
 {
 	connected_ = false;
 

--- a/simple-serial-port/simple-serial-port/SimpleSerial.h
+++ b/simple-serial-port/simple-serial-port/SimpleSerial.h
@@ -28,7 +28,7 @@ private:
 	void CustomSyntax(string syntax_type);	
 
 public:
-	SimpleSerial(char* com_port, DWORD COM_BAUD_RATE);
+	void init(char* com_port, DWORD COM_BAUD_RATE);
 
 	string ReadSerialPort(int reply_wait_time, string syntax_type);	
 	bool WriteSerialPort(char *data_sent);


### PR DESCRIPTION
Now it is possible to create a SimpleSerial Object globally and change the initializer with his _com_port_ and _COM_BAUD_RATE_ later if needed.

Example main sketch:

```
SimpleSerial simple_serial;
cout<<"\n COM_PORT: ";
cin>> com_port;
cout<<"\n BAUD_RATE: ";
cin>> com_baud_rate;
simple_serial.init(com_port, com_baud_rate);
cout<<"Serial connection changed!\n";
```