### PR TITLE
Fixed signatures + removed unnecessary code duplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ char com_port[] = "\\\\.\\COM8";
 DWORD COM_BAUD_RATE = CBR_9600;
 SimpleSerial Serial(com_port, COM_BAUD_RATE);
 
-if(connected_) {
+if(Serial.IsConnected()) {
     //do whatever
 }
 ```

--- a/simple-serial-port/simple-serial-port/SimpleSerial.cpp
+++ b/simple-serial-port/simple-serial-port/SimpleSerial.cpp
@@ -1,6 +1,3 @@
-#ifdef _MSC_VER
-#include "stdafx.h"
-#endif
 #include "SimpleSerial.h"
 
 #include <stdio.h>
@@ -14,48 +11,7 @@
 
 SimpleSerial::SimpleSerial(const std::string &com_port, DWORD COM_BAUD_RATE)
 {
-    io_handler_ = CreateFileA(com_port.c_str(),
-                              GENERIC_READ | GENERIC_WRITE,
-                              0,
-                              nullptr,
-                              OPEN_EXISTING,
-                              FILE_ATTRIBUTE_NORMAL,
-                              nullptr);
-
-    if (io_handler_ == INVALID_HANDLE_VALUE)
-    {
-        if (GetLastError() == ERROR_FILE_NOT_FOUND)
-        {
-            std::cout << "Warning: Handle was not attached. Reason: " << com_port << " not available\n";
-        }
-    }
-    else
-    {
-        DCB dcbSerialParams = {0};
-
-        if (!GetCommState(io_handler_, &dcbSerialParams))
-        {
-            std::cout << "Warning: Failed to get current serial params\n";
-        }
-        else
-        {
-            dcbSerialParams.BaudRate = COM_BAUD_RATE;
-            dcbSerialParams.ByteSize = 8;
-            dcbSerialParams.StopBits = ONESTOPBIT;
-            dcbSerialParams.Parity = NOPARITY;
-            dcbSerialParams.fDtrControl = DTR_CONTROL_ENABLE;
-
-            if (!SetCommState(io_handler_, &dcbSerialParams))
-            {
-                std::cout << "Warning: could not set serial port params\n";
-            }
-            else
-            {
-                connected_ = true;
-                PurgeComm(io_handler_, PURGE_RXCLEAR | PURGE_TXCLEAR);
-            }
-        }
-    }
+    this->init(com_port, COM_BAUD_RATE);
 }
 
 SimpleSerial::~SimpleSerial()
@@ -119,7 +75,7 @@ void SimpleSerial::init(const std::string &com_port, DWORD COM_BAUD_RATE)
     }
 }
 
-void SimpleSerial::CustomSyntax(const std::string &syntax_type)
+void SimpleSerial::CustomSyntax(std::string syntax_type)
 {
     std::ifstream syntaxfile_exist("syntax_config.txt");
 
@@ -174,7 +130,7 @@ void SimpleSerial::CustomSyntax(const std::string &syntax_type)
     }
 }
 
-std::string SimpleSerial::ReadSerialPort(int reply_wait_time, std::string syntax_type)
+std::string SimpleSerial::ReadSerialPort(int reply_wait_time, const std::string& syntax_type)
 {
     DWORD bytes_read;
     char inc_msg[1];
@@ -248,7 +204,7 @@ bool SimpleSerial::CloseSerialPort()
     }
 }
 
-bool SimpleSerial::IsConnected() const
+bool SimpleSerial::IsConnected() 
 {
     return connected_;
 }


### PR DESCRIPTION
- Updated connected reference on readme
- Removed 'stdafx.h' (Let user configure precompiled headers ) 
- Removed duplicated code at constructor (Now calling directly `init` function).
- Fixed mismatching signatures at `CustomSyntax` & `ReadSerialPort` and `IsConnected`

- Build tested on Visual Studio 2022 and G++ (MinGW-W64 x86_64-ucrt-posix-seh, built by Brecht Sanders) 12.2.0